### PR TITLE
Sc 97669/update qtwebdriver to use GitHub workflows

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,22 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/ubuntu
+{
+	"name": "Ubuntu",
+	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+	"image": "mcr.microsoft.com/devcontainers/base:jammy",
+
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "/bin/bash .devcontainer/setup.sh"
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -5,7 +5,7 @@ sudo apt-get -y update
 # Enable tab autocomplete in terminal
 sudo apt install bash-completion
 
-# Install tools required to build
+# Install tools/libraries required to build
 sudo apt-get install -y \
     gyp \
     libegl1-mesa-dev \
@@ -18,9 +18,29 @@ sudo apt-get install -y \
     libpng-dev \
     libxslt1-dev \
 
+# Install Qt
+sudo apt-get install -y \
+    qtbase5-dev \
+    qtdeclarative5-dev \
+    qtmultimedia5-dev \
+    qtpositioning5-dev \
+    libqt5sensors5-dev \
+    libqt5webchannel5 \
+    qt5-qmake \
+
 # Alias python3 to python so the build script can find it
 sudo ln -s /usr/bin/python3 /usr/bin/python
 
-# Download our prebuilt version of Qt
-curl -L https://github.com/constructpm/qt-build/releases/download/v5.15.8-lts-lgpl-1/qt-5.15.8-lts-lgpl-cpp17-ubuntu-22.04-x64.tar.gz | sudo tar -xJC /opt
-curl -L https://github.com/constructpm/qtwebkit-build/releases/download/v5.212.0-1/qtwebkit-d1c854e-cpp17-ubuntu-22.04-x64.tar.gz | sudo tar xvJ -C /opt
+# Download our prebuilt version of QtWebkit
+curl -L https://github.com/constructpm/qtwebkit-build/releases/download/v5.212.0-1/qtwebkit-d1c854e-cpp17-ubuntu-22.04-x64.tar.gz | sudo tar xvJ -C /usr/include/x86_64-linux-gnu
+
+# Move the files we downloaded so their locations match the locations used by the other Qt libraries we installed earlier
+sudo mv /usr/include/x86_64-linux-gnu/qt5/include/* /usr/include/x86_64-linux-gnu/qt5/
+sudo mv /usr/include/x86_64-linux-gnu/qt5/lib/* /usr/lib/x86_64-linux-gnu/
+sudo mv /usr/include/x86_64-linux-gnu/qt5/lib/cmake/* /usr/lib/x86_64-linux-gnu/cmake/
+sudo mv /usr/include/x86_64-linux-gnu/qt5/lib/pkgconfig/* /usr/lib/x86_64-linux-gnu/pkgconfig/
+
+sudo rmdir /usr/include/x86_64-linux-gnu/qt5/include/
+sudo rmdir /usr/include/x86_64-linux-gnu/qt5/lib/cmake/
+sudo rmdir /usr/include/x86_64-linux-gnu/qt5/lib/pkgconfig/
+sudo rmdir /usr/include/x86_64-linux-gnu/qt5/lib/

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+sudo apt-get -y update 
+
+# Enable tab autocomplete in terminal
+sudo apt install bash-completion
+
+# Install tools required to build
+sudo apt-get install -y \
+    gyp \
+    libegl1-mesa-dev \
+    libglib2.0-dev \
+    libgstreamer1.0-dev \
+    libgstreamer-plugins-base1.0-dev \
+    libhyphen-dev \
+    libicu-dev \
+    libjpeg-dev \
+    libpng-dev \
+    libxslt1-dev \
+
+# Alias python3 to python so the build script can find it
+sudo ln -s /usr/bin/python3 /usr/bin/python
+
+# Download our prebuilt version of Qt
+curl -L https://github.com/constructpm/qt-build/releases/download/v5.15.8-lts-lgpl-1/qt-5.15.8-lts-lgpl-cpp17-ubuntu-22.04-x64.tar.gz | sudo tar -xJC /opt
+curl -L https://github.com/constructpm/qtwebkit-build/releases/download/v5.212.0-1/qtwebkit-d1c854e-cpp17-ubuntu-22.04-x64.tar.gz | sudo tar xvJ -C /opt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
+    branches: [WD_1.X_dev]
     paths-ignore:
       - '**/*.md'
   push:
@@ -11,20 +11,7 @@ on:
       - v*
 
 env:
-  QTVERSION: 5.15.0-lts
-  BUILD_CONFIG: "{
-      'variables': {
-        'QT5': '1',
-        'WD_CONFIG_QWIDGET_BASE': '1',
-        'WD_CONFIG_WEBKIT': '0',
-        'WD_CONFIG_QUICK': '1',
-        'WD_CONFIG_PLAYER': '0',
-        'WD_CONFIG_ONE_KEYRELEASE': '0',
-        'QT_INC_PATH': '/opt/qt5/include',
-        'QT_BIN_PATH': '/opt/qt5/bin',
-        'QT_LIB_PATH': '/opt/qt5/lib'
-      },
-    }"
+  QTVERSION: 5.15.8-lts-lgpl
 
 jobs:
   tar-src:
@@ -76,25 +63,27 @@ jobs:
             libicu-dev \
             libjpeg-dev \
             libpng-dev \
+            libunwind-dev \
             libxslt1-dev \
       - name: Install Qt
-        run: curl -L https://github.com/constructpm/qt-build/releases/download/v5.15.8-lts-lgpl-1/qt-5.15.8-lts-lgpl-cpp17-${{ matrix.config.os }}x64.tar.gz | sudo tar -xJC /opt
+        run: curl -L https://github.com/constructpm/qt-build/releases/download/v5.15.8-lts-lgpl-1/qt-5.15.8-lts-lgpl-cpp17-${{ matrix.config.os }}-x64.tar.gz | sudo tar -xJC /opt
       - name: Install Qtwebkit
         run: curl -L https://github.com/constructpm/qtwebkit-build/releases/download/v5.212.0-1/qtwebkit-d1c854e-cpp17-${{ matrix.config.os }}-x64.tar.gz | sudo tar xvJ -C /opt
       - name: checkout
         uses: actions/checkout@v4
-      - name: Configure
-        run: echo ${BUILDCONFIG} > wd.gypi
       - name: Build
-        run: build.sh
+        working-directory: ${{ github.workspace }}
+        run: ./build.sh
       - name: Archive
-        working-directory: ${{ github.workspace }}/opt
-        run: tar cJfv "${{ steps.config.outputs.artefact_name }}" qtwebdriver
+        working-directory: ${{ github.workspace }}
+        run: |
+          mv out qtwebdriver
+          tar cJfv "${{ steps.config.outputs.artefact_name }}" qtwebdriver
       - name: Upload
         uses: actions/upload-artifact@v4
         with:
           name: "${{ steps.config.outputs.artefact_name }}"
-          path: "${{ github.workspace }}/opt/${{ steps.config.outputs.artefact_name }}"
+          path: "${{ github.workspace }}/${{ steps.config.outputs.artefact_name }}"
 
   release:
     if: contains(github.ref, 'tags/v')

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,8 @@ on:
       - v*
 
 env:
-  QTVERSION: 5.15.8-lts-lgpl
+  # 5.15.3 is the version of Qt you get when you install qt5 libraries via `apt install`
+  QTVERSION: 5.15.3
 
 jobs:
   tar-src:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,9 +66,31 @@ jobs:
             libunwind-dev \
             libxslt1-dev \
       - name: Install Qt
-        run: curl -L https://github.com/constructpm/qt-build/releases/download/v5.15.8-lts-lgpl-1/qt-5.15.8-lts-lgpl-cpp17-${{ matrix.config.os }}-x64.tar.gz | sudo tar -xJC /opt
+        run: |
+          sudo apt-get -o Acquire::Retries=3 install -y \
+            qtbase5-dev \
+            qtdeclarative5-dev \
+            qtmultimedia5-dev \
+            qtpositioning5-dev \
+            libqt5sensors5-dev \
+            libqt5webchannel5 \
+            qt5-qmake \
       - name: Install Qtwebkit
-        run: curl -L https://github.com/constructpm/qtwebkit-build/releases/download/v5.212.0-1/qtwebkit-d1c854e-cpp17-${{ matrix.config.os }}-x64.tar.gz | sudo tar xvJ -C /opt
+        run: |
+          curl -L https://github.com/constructpm/qtwebkit-build/releases/download/v5.212.0-1/qtwebkit-d1c854e-cpp17-ubuntu-22.04-x64.tar.gz | sudo tar xvJ -C /usr/include/x86_64-linux-gnu
+          
+          # Move the files we downloaded so their locations match the locations used by the other Qt libraries we installed earlier
+          sudo mv /usr/include/x86_64-linux-gnu/qt5/include/* /usr/include/x86_64-linux-gnu/qt5/
+          sudo rmdir /usr/include/x86_64-linux-gnu/qt5/include/
+
+          sudo mv /usr/include/x86_64-linux-gnu/qt5/lib/cmake/* /usr/lib/x86_64-linux-gnu/cmake/
+          sudo rmdir /usr/include/x86_64-linux-gnu/qt5/lib/cmake/
+
+          sudo mv /usr/include/x86_64-linux-gnu/qt5/lib/pkgconfig/* /usr/lib/x86_64-linux-gnu/pkgconfig/
+          sudo rmdir /usr/include/x86_64-linux-gnu/qt5/lib/pkgconfig/
+          
+          sudo mv /usr/include/x86_64-linux-gnu/qt5/lib/* /usr/lib/x86_64-linux-gnu/
+          sudo rmdir /usr/include/x86_64-linux-gnu/qt5/lib/
       - name: checkout
         uses: actions/checkout@v4
       - name: Build

--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ report/*
 /build/
 /docs/
 /mocs/
-wd.gypi
 /wd.Makefile
 /Makefile
 /WebDriver.target.mk

--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,30 @@
-# Synopsis
+# Description
+
+This Repo contains a fork of the QtWebDriver source code. We need this because the automated Robot tests in boron use it (and maybe a few other things?).
+
+This repo contains:
+- The source code for qtwebkit (originally from cisco)
+- A devcontainer that can be used for development/building of the source
+- A github action that automatically builds the code on pull requests, and builds a release when a version tag (`v1` or equivalent) is pushed.
+
+The intended usage is:
+1. make any changes you need
+2. (optional) use the devcontainer to confirm the builds succeed locally (open the dev container and run `build.sh`)
+3. create PR and get it approved
+4. push a version tag to create a release
+5. use the release build anywhere you need a qtwebdriver build
+
+To use the release, you can download it with a command that looks like the following:
+```bash
+curl -L https://github.com/constructpm/qtwebdriver/releases/download/v5.15.3-dev-1/qtwebdriver-5.15.8-lts-lgpl-cpp17-ubuntu-22.04-x64.tar.gz | sudo tar xvJ -C /opt
+```
+
+This process is intended to match the process used to get a build of Qt from [qt-build](https://github.com/constructpm/qt-build), and a build of QtWebkit from [qtwebkit-build](https://github.com/constructpm/qtwebkit-build) do.
+It replaces the old process of building the binary manually and placing it in a shared storage area.
+
+# Old Readme
+
+## Synopsis
 QtWebDriver is a WebDriver implementation for Qt.
 
 It can be used to perform automated Selenium testing of applications based on:
@@ -10,15 +36,15 @@ If you hadn't used Selenium for automated testing, you may also find this links 
 * https://github.com/seleniumhq/selenium
 * http://docs.seleniumhq.org/  
 
-# Build and run
+## Build and run
 * The build instructions are detailed in the wiki: https://github.com/cisco-open-source/qtwebdriver/wiki/Build-And-Run
 * Release notes and pre-built binaries are in the Releases section: https://github.com/cisco-open-source/qtwebdriver/releases
 
-# Other links
+## Other links
 * An example how to customize QtWebDriver in `src/Test/main.cc`   
 * [Doxygen](http://cisco-open-source.github.io/qtwebdriver/html)  
 * [Wiki](https://github.com/cisco-open-source/qtwebdriver/wiki)  
 * Mailing list: qtwebdriver-users@external.cisco.com
 
-# License
+## License
 LGPLv2.1

--- a/do_if_modified.py
+++ b/do_if_modified.py
@@ -3,8 +3,8 @@ import os
 import sys
 
 if (len(sys.argv) != 4):
-    print 'Wrong usage:'
-    print ' do_if_modified <bin_file> <input_file> <output_file>'
+    print('Wrong usage:')
+    print(' do_if_modified <bin_file> <input_file> <output_file>')
     exit()
 
 action_process = os.path.abspath(sys.argv[1])

--- a/generate_wdversion.py
+++ b/generate_wdversion.py
@@ -11,7 +11,7 @@ versionfile.write("extern const char kProductName[] = \"WebDriver-cisco-cmt\";\n
 versionfile.write("extern const char kVersionNumber[] = \"1.3.3\";\n")
 versionfile.write("extern const char kBuildTime[] = __TIME__;\n")
 versionfile.write("extern const char kBuildDate[] = __DATE__;\n")
-versionfile.write("extern const char kLastChanges[] = \"" + data.strip() + "\";\n")
+versionfile.write("extern const char kLastChanges[] = \"" + data.strip().decode() + "\";\n")
 versionfile.write("}")
 versionfile.close()
 

--- a/wd.gypi
+++ b/wd.gypi
@@ -1,0 +1,13 @@
+{
+    'variables': {
+        'QT5': '1',
+        'WD_CONFIG_QWIDGET_BASE': '1',
+        'WD_CONFIG_WEBKIT': '0',
+        'WD_CONFIG_QUICK': '1',
+        'WD_CONFIG_PLAYER': '0',
+        'WD_CONFIG_ONE_KEYRELEASE': '0',
+        'QT_INC_PATH': '/opt/qt5/include',
+        'QT_BIN_PATH': '/opt/qt5/bin',
+        'QT_LIB_PATH': '/opt/qt5/lib'
+    },
+}

--- a/wd.gypi
+++ b/wd.gypi
@@ -2,12 +2,12 @@
     'variables': {
         'QT5': '1',
         'WD_CONFIG_QWIDGET_BASE': '1',
-        'WD_CONFIG_WEBKIT': '0',
+        'WD_CONFIG_WEBKIT': '1',
         'WD_CONFIG_QUICK': '1',
         'WD_CONFIG_PLAYER': '0',
         'WD_CONFIG_ONE_KEYRELEASE': '0',
-        'QT_INC_PATH': '/opt/qt5/include',
-        'QT_BIN_PATH': '/opt/qt5/bin',
-        'QT_LIB_PATH': '/opt/qt5/lib'
+        'QT_INC_PATH': '/usr/include/x86_64-linux-gnu/qt5',
+        'QT_BIN_PATH': '/usr/bin',
+        'QT_LIB_PATH': '/usr/lib/x86_64-linux-gnu'
     },
 }

--- a/wd_build_options.gypi
+++ b/wd_build_options.gypi
@@ -11,7 +11,7 @@
     '-Wall',
     '-W',
     '-Wno-unused-parameter',
-    '-std=gnu++11',
+    '-std=gnu++17',
   ],
 
   'defines': [


### PR DESCRIPTION
## Description

PR to start using Github Actions to build releases of this codebase. This is to align this repo with our other QT repos, [qt-build](https://github.com/constructpm/qt-build) and [qtwebkit-build](https://github.com/constructpm/qtwebkit-build).

It also includes the addition of a devcontainer. This makes it much easier to build locally as you won't need to setup the necessary environment manually. Just open the devcontainer and run `build.sh`