### PR TITLE
chore(ci)[sc-98275]: build for webengine not webkit

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -27,6 +27,4 @@ sudo apt-get install -y \
 sudo ln -s /usr/bin/python3 /usr/bin/python
 
 # Download our prebuilt version of Qt
-curl -L https://github.com/constructpm/qt-build/releases/download/v6.7.1-1/qt-6.7.1-cpp17-ubuntu-22.04-x64.tar.gz | sudo tar xvJ -C /opt
-# Download our prebuilt version of QtWebkit
-curl -L https://github.com/constructpm/qtwebkit-build/releases/download/v6.212.0-1/qtwebkit-ee690e4-cpp17-ubuntu-22.04-x64.tar.gz | sudo tar xvJ -C /opt
+curl -L https://github.com/constructpm/qt-build/releases/download/v6.7.1-2/qt-6.7.1-cpp17-ubuntu-22.04-x64.tar.gz | sudo tar xvJ -C /opt

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,11 +74,7 @@ jobs:
 
       - name: Install Qt
         run: |
-          curl -L https://github.com/constructpm/qt-build/releases/download/v6.7.1-1/qt-6.7.1-cpp17-ubuntu-22.04-x64.tar.gz | sudo tar xvJ -C /opt
-
-      - name: Install Qtwebkit
-        run: |
-          curl -L https://github.com/constructpm/qtwebkit-build/releases/download/v6.212.0-1/qtwebkit-ee690e4-cpp17-ubuntu-22.04-x64.tar.gz | sudo tar xvJ -C /opt
+          curl -L https://github.com/constructpm/qt-build/releases/download/v6.7.1-2/qt-6.7.1-cpp17-ubuntu-22.04-x64.tar.gz | sudo tar xvJ -C /opt
 
       - name: checkout
         uses: actions/checkout@v4

--- a/wd.gypi
+++ b/wd.gypi
@@ -2,7 +2,7 @@
     'variables': {
         'QT6': '1',
         'WD_CONFIG_QWIDGET_BASE': '1',
-        'WD_CONFIG_WEBKIT': '1',
+        'WD_CONFIG_WEBKIT': '0',
         'WD_CONFIG_QUICK': '1',
         'WD_CONFIG_PLAYER': '0',
         'WD_CONFIG_ONE_KEYRELEASE': '0',


### PR DESCRIPTION
## Description

PR to build qtwebdriver for qtwebengine rather than qtwebkit.
This is part of the work to remove qtwebkit from Boron to allow the Qt6 upgrade to take place.